### PR TITLE
[COMPLETED] Add dynamic load balancing with Round Robin & Least Connections

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,22 +3,23 @@ package main
 import (
 	"fmt"
 	"log"
-
+	"net/http"
 	"github.com/FLASH2332/novus-load-balancer/config"
 	"github.com/FLASH2332/novus-load-balancer/internal/proxy"
-	"net/http"
 )
 
 func main() {
 	// Load configuration
 	config.LoadConfig("config/config.yaml")
 
-	// Create a new reverse proxy
-	reverseProxy := proxy.NewReverseProxy(config.Cfg.Proxy.Targets)
+	// Choose strategy from config
+	strategy := config.Cfg.LoadBalancer.Strategy // "round_robin" or "least_connections"
+
+	// Create the reverse proxy
+	reverseProxy := proxy.NewReverseProxy(config.Cfg.Proxy.Targets, strategy)
 
 	// Start the server
 	port := config.Cfg.Server.Port
-	fmt.Printf("Reverse Proxy running on port %d\n", port)
+	fmt.Printf("Reverse Proxy running on port %d with %s strategy\n", port, strategy)
 	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", port), reverseProxy))
-
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1,39 +1,148 @@
 package proxy
 
 import (
+	"log"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
-	"log"
+	"sync"
+	"sync/atomic"
+	"time"
 )
 
-// ReverseProxy struct
-type ReverseProxy struct {
-	TargetURLs []*url.URL
+// Backend struct with connection count
+type Backend struct {
+	URL          *url.URL
+	Alive        bool
+	mux          sync.RWMutex
+	Connections  uint64 // Tracks active connections
+	ReverseProxy *httputil.ReverseProxy
 }
 
-// NewReverseProxy initializes the proxy with target URLs
-func NewReverseProxy(targets []string) *ReverseProxy {
-	var urls []*url.URL
+// ReverseProxy struct with strategy selection
+type ReverseProxy struct {
+	Backends   []*Backend
+	currentIdx uint64
+	Strategy   string // "round_robin" or "least_connections"
+}
+
+// NewReverseProxy initializes the proxy with target URLs and strategy
+func NewReverseProxy(targets []string, strategy string) *ReverseProxy {
+	var backends []*Backend
 	for _, target := range targets {
 		parsedURL, err := url.Parse(target)
 		if err != nil {
 			log.Fatalf("Invalid target URL: %v", err)
 		}
-		urls = append(urls, parsedURL)
+		backends = append(backends, &Backend{
+			URL:          parsedURL,
+			Alive:        true,
+			Connections:  0,
+			ReverseProxy: httputil.NewSingleHostReverseProxy(parsedURL),
+		})
 	}
-	return &ReverseProxy{TargetURLs: urls}
+	rp := &ReverseProxy{Backends: backends, Strategy: strategy}
+	go rp.healthCheckLoop() // Start passive health checks
+	return rp
 }
 
-// ServeHTTP forwards requests to backend servers
+// getNextBackend selects backend based on strategy
+func (rp *ReverseProxy) getNextBackend() *Backend {
+	if rp.Strategy == "least_connections" {
+		return rp.getLeastConnectionsBackend()
+	}
+	return rp.getRoundRobinBackend()
+}
+
+// Round Robin Selection
+func (rp *ReverseProxy) getRoundRobinBackend() *Backend {
+	for i := 0; i < len(rp.Backends); i++ {
+		idx := atomic.AddUint64(&rp.currentIdx, 1) % uint64(len(rp.Backends))
+		backend := rp.Backends[idx]
+		backend.mux.RLock()
+		alive := backend.Alive
+		backend.mux.RUnlock()
+		if alive {
+			return backend
+		}
+	}
+	return nil
+}
+
+// Least Connections Selection
+func (rp *ReverseProxy) getLeastConnectionsBackend() *Backend {
+	var selected *Backend
+	minConnections := uint64(^uint(0)) // Max uint value
+
+	for _, backend := range rp.Backends {
+		backend.mux.RLock()
+		alive := backend.Alive
+		connections := backend.Connections
+		backend.mux.RUnlock()
+
+		if alive && connections < minConnections {
+			selected = backend
+			minConnections = connections
+		}
+	}
+	return selected
+}
+
+// ServeHTTP with Active Connection Tracking
 func (rp *ReverseProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	target := rp.TargetURLs[0] // For now, always select the first target
+	backend := rp.getNextBackend()
+	if backend == nil {
+		http.Error(w, "No backend available", http.StatusServiceUnavailable)
+		return
+	}
 
-	proxy := httputil.NewSingleHostReverseProxy(target)
-	r.URL.Host = target.Host
-	r.URL.Scheme = target.Scheme
-	r.Host = target.Host
+	// Increase connection count
+	atomic.AddUint64(&backend.Connections, 1)
+	defer atomic.AddUint64(&backend.Connections, ^uint64(0)) // Decrease after request
 
-	log.Printf("Forwarding request to: %s%s", target, r.URL.Path)
-	proxy.ServeHTTP(w, r)
+	log.Printf("Forwarding request to: %s%s (Connections: %d)", backend.URL, r.URL.Path, backend.Connections)
+	backend.ReverseProxy.ServeHTTP(w, r)
+}
+
+// healthCheckLoop and isBackendAlive remain the same
+
+func (rp *ReverseProxy) healthCheckLoop() {
+	for {
+		time.Sleep(5 * time.Second) // Check every 5 seconds
+		log.Println("Running health check...") // Add this to confirm it's running
+
+		for _, backend := range rp.Backends {
+			alive := isBackendAlive(backend.URL)
+
+			backend.mux.Lock()
+			wasAlive := backend.Alive
+			backend.Alive = alive
+			backend.mux.Unlock()
+
+			// Log when backend status changes
+			if wasAlive && !alive {
+				log.Printf("❌ Backend %s is DOWN!", backend.URL)
+			} else if !wasAlive && alive {
+				log.Printf("✅ Backend %s is BACK ONLINE!", backend.URL)
+			}
+		}
+	}
+}
+
+
+func isBackendAlive(url *url.URL) bool {
+	client := http.Client{
+		Timeout: 2 * time.Second, // Prevents hanging if the server is dead
+	}
+	req, err := http.NewRequest("HEAD", url.String(), nil) // Use HEAD instead of GET
+	if err != nil {
+		return false
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Printf("❌ Health check failed for %s: %v", url, err)
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode < 500
 }


### PR DESCRIPTION
Solves #3 

-  Modified ReverseProxy to select the backend dynamically based on strategy.
- Updated config.yaml to allow selecting the strategy.
- Continuously monitor server health and log when a server goes down.