### PR TITLE
Refactor Load Balancer: Separate Load Balancing Logic into internal/loadbalancer/lb.go

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+
 	"github.com/FLASH2332/novus-load-balancer/config"
 	"github.com/FLASH2332/novus-load-balancer/internal/proxy"
 )
@@ -13,7 +14,7 @@ func main() {
 	config.LoadConfig("config/config.yaml")
 
 	// Choose strategy from config
-	strategy := config.Cfg.LoadBalancer.Strategy // "round_robin" or "least_connections"
+	strategy := config.Cfg.LoadBalancer.Strategy
 
 	// Create the reverse proxy
 	reverseProxy := proxy.NewReverseProxy(config.Cfg.Proxy.Targets, strategy)

--- a/internal/loadbalancer/lb.go
+++ b/internal/loadbalancer/lb.go
@@ -1,0 +1,124 @@
+package loadbalancer
+
+import (
+	"log"
+	"net/http"
+	"net/url"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Backend struct to store server state
+type Backend struct {
+	URL         *url.URL
+	Alive       bool
+	Connections uint64
+	mux         sync.RWMutex
+}
+
+// LoadBalancer struct
+type LoadBalancer struct {
+	Backends   []*Backend
+	currentIdx uint64
+	Strategy   string // "round_robin" or "least_connections"
+}
+
+// NewLoadBalancer initializes the load balancer
+func NewLoadBalancer(targets []string, strategy string) *LoadBalancer {
+	var backends []*Backend
+	for _, target := range targets {
+		parsedURL, err := url.Parse(target)
+		if err != nil {
+			log.Fatalf("Invalid target URL: %v", err)
+		}
+		backends = append(backends, &Backend{
+			URL:         parsedURL,
+			Alive:       true,
+			Connections: 0,
+		})
+	}
+	lb := &LoadBalancer{Backends: backends, Strategy: strategy}
+	go lb.HealthCheckLoop() // Start health checks in the background
+	return lb
+}
+
+// GetNextBackend selects a backend based on strategy
+func (lb *LoadBalancer) GetNextBackend() *Backend {
+	if lb.Strategy == "least_connections" {
+		return lb.getLeastConnectionsBackend()
+	}
+	return lb.getRoundRobinBackend()
+}
+
+// Round Robin Selection
+func (lb *LoadBalancer) getRoundRobinBackend() *Backend {
+	for i := 0; i < len(lb.Backends); i++ {
+		idx := atomic.AddUint64(&lb.currentIdx, 1) % uint64(len(lb.Backends))
+		if lb.Backends[idx].Alive {
+			return lb.Backends[idx]
+		}
+	}
+	return nil
+}
+
+// Least Connections Selection
+func (lb *LoadBalancer) getLeastConnectionsBackend() *Backend {
+	var selected *Backend
+	minConnections := uint64(^uint(0)) // Max uint value
+
+	for _, backend := range lb.Backends {
+		backend.mux.RLock()
+		alive := backend.Alive
+		connections := backend.Connections
+		backend.mux.RUnlock()
+
+		if alive && connections < minConnections {
+			selected = backend
+			minConnections = connections
+		}
+	}
+	return selected
+}
+
+// HealthCheckLoop periodically pings backends to check availability
+func (lb *LoadBalancer) HealthCheckLoop() {
+	for {
+		time.Sleep(5 * time.Second) // Check every 5 seconds
+		log.Println("Running health check...")
+
+		for _, backend := range lb.Backends {
+			alive := isBackendAlive(backend.URL)
+
+			backend.mux.Lock()
+			wasAlive := backend.Alive
+			backend.Alive = alive
+			backend.mux.Unlock()
+
+			// Log when backend status changes
+			if wasAlive && !alive {
+				log.Printf("❌ Backend %s is DOWN!", backend.URL)
+			} else if !wasAlive && alive {
+				log.Printf("✅ Backend %s is BACK ONLINE!", backend.URL)
+			}
+		}
+	}
+}
+
+// isBackendAlive checks if a backend is alive
+func isBackendAlive(url *url.URL) bool {
+	client := http.Client{
+		Timeout: 2 * time.Second, // Prevents hanging if the server is dead
+	}
+	req, err := http.NewRequest("HEAD", url.String(), nil) // Use HEAD instead of GET
+	if err != nil {
+		return false
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Printf("❌ Health check failed for %s: %v", url, err)
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode < 500
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -4,93 +4,25 @@ import (
 	"log"
 	"net/http"
 	"net/http/httputil"
-	"net/url"
-	"sync"
 	"sync/atomic"
-	"time"
+
+	"github.com/FLASH2332/novus-load-balancer/internal/loadbalancer"
 )
 
-// Backend struct with connection count
-type Backend struct {
-	URL          *url.URL
-	Alive        bool
-	mux          sync.RWMutex
-	Connections  uint64 // Tracks active connections
-	ReverseProxy *httputil.ReverseProxy
-}
-
-// ReverseProxy struct with strategy selection
+// ReverseProxy struct
 type ReverseProxy struct {
-	Backends   []*Backend
-	currentIdx uint64
-	Strategy   string // "round_robin" or "least_connections"
+	LB *loadbalancer.LoadBalancer
 }
 
-// NewReverseProxy initializes the proxy with target URLs and strategy
+// NewReverseProxy initializes the reverse proxy
 func NewReverseProxy(targets []string, strategy string) *ReverseProxy {
-	var backends []*Backend
-	for _, target := range targets {
-		parsedURL, err := url.Parse(target)
-		if err != nil {
-			log.Fatalf("Invalid target URL: %v", err)
-		}
-		backends = append(backends, &Backend{
-			URL:          parsedURL,
-			Alive:        true,
-			Connections:  0,
-			ReverseProxy: httputil.NewSingleHostReverseProxy(parsedURL),
-		})
-	}
-	rp := &ReverseProxy{Backends: backends, Strategy: strategy}
-	go rp.healthCheckLoop() // Start passive health checks
-	return rp
+	lb := loadbalancer.NewLoadBalancer(targets, strategy)
+	return &ReverseProxy{LB: lb}
 }
 
-// getNextBackend selects backend based on strategy
-func (rp *ReverseProxy) getNextBackend() *Backend {
-	if rp.Strategy == "least_connections" {
-		return rp.getLeastConnectionsBackend()
-	}
-	return rp.getRoundRobinBackend()
-}
-
-// Round Robin Selection
-func (rp *ReverseProxy) getRoundRobinBackend() *Backend {
-	for i := 0; i < len(rp.Backends); i++ {
-		idx := atomic.AddUint64(&rp.currentIdx, 1) % uint64(len(rp.Backends))
-		backend := rp.Backends[idx]
-		backend.mux.RLock()
-		alive := backend.Alive
-		backend.mux.RUnlock()
-		if alive {
-			return backend
-		}
-	}
-	return nil
-}
-
-// Least Connections Selection
-func (rp *ReverseProxy) getLeastConnectionsBackend() *Backend {
-	var selected *Backend
-	minConnections := uint64(^uint(0)) // Max uint value
-
-	for _, backend := range rp.Backends {
-		backend.mux.RLock()
-		alive := backend.Alive
-		connections := backend.Connections
-		backend.mux.RUnlock()
-
-		if alive && connections < minConnections {
-			selected = backend
-			minConnections = connections
-		}
-	}
-	return selected
-}
-
-// ServeHTTP with Active Connection Tracking
+// ServeHTTP forwards requests to backend servers
 func (rp *ReverseProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	backend := rp.getNextBackend()
+	backend := rp.LB.GetNextBackend()
 	if backend == nil {
 		http.Error(w, "No backend available", http.StatusServiceUnavailable)
 		return
@@ -101,48 +33,6 @@ func (rp *ReverseProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer atomic.AddUint64(&backend.Connections, ^uint64(0)) // Decrease after request
 
 	log.Printf("Forwarding request to: %s%s (Connections: %d)", backend.URL, r.URL.Path, backend.Connections)
-	backend.ReverseProxy.ServeHTTP(w, r)
-}
-
-// healthCheckLoop and isBackendAlive remain the same
-
-func (rp *ReverseProxy) healthCheckLoop() {
-	for {
-		time.Sleep(5 * time.Second) // Check every 5 seconds
-		log.Println("Running health check...") // Add this to confirm it's running
-
-		for _, backend := range rp.Backends {
-			alive := isBackendAlive(backend.URL)
-
-			backend.mux.Lock()
-			wasAlive := backend.Alive
-			backend.Alive = alive
-			backend.mux.Unlock()
-
-			// Log when backend status changes
-			if wasAlive && !alive {
-				log.Printf("❌ Backend %s is DOWN!", backend.URL)
-			} else if !wasAlive && alive {
-				log.Printf("✅ Backend %s is BACK ONLINE!", backend.URL)
-			}
-		}
-	}
-}
-
-
-func isBackendAlive(url *url.URL) bool {
-	client := http.Client{
-		Timeout: 2 * time.Second, // Prevents hanging if the server is dead
-	}
-	req, err := http.NewRequest("HEAD", url.String(), nil) // Use HEAD instead of GET
-	if err != nil {
-		return false
-	}
-	resp, err := client.Do(req)
-	if err != nil {
-		log.Printf("❌ Health check failed for %s: %v", url, err)
-		return false
-	}
-	defer resp.Body.Close()
-	return resp.StatusCode < 500
+	proxy := httputil.NewSingleHostReverseProxy(backend.URL)
+	proxy.ServeHTTP(w, r)
 }


### PR DESCRIPTION
Solves #5 
### Summary:
This PR refactors the load balancer by **separating load balancing logic from `proxy.go`** into `internal/loadbalancer/lb.go`.  
Now, `proxy.go` only handles **request forwarding**, while `lb.go` manages **backend selection, health checks, and load balancing strategies**.

### Changes:
- **Moved backend selection & health checks** to `internal/loadbalancer/lb.go`.
- **Updated `proxy.go`** to call `LoadBalancer` for selecting backends.
- **Supports both** `Round Robin` & `Least Connections` strategies.
- **Ensures health checks still function correctly**.