### PR TITLE
Integrate Cache with Proxy server

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,7 +17,7 @@ func main() {
 	strategy := config.Cfg.LoadBalancer.Strategy
 
 	// Create the reverse proxy
-	reverseProxy := proxy.NewReverseProxy(config.Cfg.Proxy.Targets, strategy)
+	reverseProxy := proxy.NewReverseProxy(config.Cfg.Proxy.Targets, strategy,config.Cfg.Cache.MaxSize)
 
 	// Start the server
 	port := config.Cfg.Server.Port

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1,27 +1,45 @@
 package proxy
 
 import (
+	"bytes"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httputil"
 	"sync/atomic"
 
+	"github.com/FLASH2332/novus-load-balancer/internal/cache"
 	"github.com/FLASH2332/novus-load-balancer/internal/loadbalancer"
 )
 
 // ReverseProxy struct
 type ReverseProxy struct {
-	LB *loadbalancer.LoadBalancer
+	LB    *loadbalancer.LoadBalancer
+	Cache *cache.LRUCache
 }
 
-// NewReverseProxy initializes the reverse proxy
-func NewReverseProxy(targets []string, strategy string) *ReverseProxy {
+// NewReverseProxy initializes the reverse proxy with cache
+func NewReverseProxy(targets []string, strategy string, cacheSize int) *ReverseProxy {
 	lb := loadbalancer.NewLoadBalancer(targets, strategy)
-	return &ReverseProxy{LB: lb}
+	return &ReverseProxy{
+		LB:    lb,
+		Cache: cache.NewLRUCache(cacheSize),
+	}
 }
 
-// ServeHTTP forwards requests to backend servers
+// ServeHTTP forwards requests to backend servers with caching
 func (rp *ReverseProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Use request URL as cache key
+	cacheKey := r.URL.String()
+
+	// Try cache first
+	if cached, ok := rp.Cache.Get(cacheKey); ok {
+		log.Printf("✅ Cache hit for %s", cacheKey)
+		w.Write(cached)
+		return
+	}
+
+	// If not cached, forward to backend
 	backend := rp.LB.GetNextBackend()
 	if backend == nil {
 		http.Error(w, "No backend available", http.StatusServiceUnavailable)
@@ -30,9 +48,28 @@ func (rp *ReverseProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Increase connection count
 	atomic.AddUint64(&backend.Connections, 1)
-	defer atomic.AddUint64(&backend.Connections, ^uint64(0)) // Decrease after request
+	defer atomic.AddUint64(&backend.Connections, ^uint64(0)) // decrease after request
 
-	log.Printf("Forwarding request to: %s%s (Connections: %d)", backend.URL, r.URL.Path, backend.Connections)
+	log.Printf("➡ Forwarding request to: %s%s", backend.URL, r.URL.Path)
+
 	proxy := httputil.NewSingleHostReverseProxy(backend.URL)
+
+	// Capture response using custom transport
+	proxy.ModifyResponse = func(resp *http.Response) error {
+		// Read body into memory
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+		resp.Body.Close()
+
+		// Save a copy to cache
+		rp.Cache.Put(cacheKey, body)
+
+		// Replace response body so client can still read it
+		resp.Body = io.NopCloser(bytes.NewBuffer(body))
+		return nil
+	}
+
 	proxy.ServeHTTP(w, r)
 }


### PR DESCRIPTION
Solves #9 

**SUMMARY:**
- Integrated cache into reverse proxy flow (proxy.go).
- Logs “✅ Cache hit” when a cached response is served.
- The cache stores backend responses and serves them directly if the same request is repeated, reducing backend load and improving performance.

<img width="1430" height="776" alt="image" src="https://github.com/user-attachments/assets/f8d50284-384c-47cf-b0d7-3cd76c2d41e2" />
